### PR TITLE
Feature/calendar

### DIFF
--- a/pages/calendar/index.tsx
+++ b/pages/calendar/index.tsx
@@ -2,11 +2,7 @@ import type { NextPage } from 'next';
 import CalendarScreen from 'src/app.features/calendar/screens/CalendarScreen';
 
 const CalendarPage: NextPage = () => {
-	return (
-		<div className="w-screen h-scree">
-			<CalendarScreen />
-		</div>
-	);
+	return <CalendarScreen />;
 };
 
 export default CalendarPage;

--- a/pages/calendar/salary-detail/[id].tsx
+++ b/pages/calendar/salary-detail/[id].tsx
@@ -1,0 +1,31 @@
+import { NextPage } from 'next';
+import { useRouter } from 'next/router';
+import ManageDetailScreen from 'src/app.features/calendar/screens/ManageDetailScreen';
+import WorkerScreen from 'src/app.features/calendar/screens/WorkerScreen';
+interface Props {
+	children: React.ReactElement | null;
+}
+
+const isAdmin = (): boolean => {
+	// 점장 유효성 검사
+	return true;
+};
+
+const Admin: React.FC<Props> = ({ children }) => {
+	const router = useRouter();
+	if (!isAdmin()) {
+		router.push(`/calendar/salary`);
+	}
+	return children;
+};
+
+const Detail: NextPage = () => {
+	const router = useRouter();
+	const { id } = router.query;
+	return (
+		<Admin>
+			<ManageDetailScreen id={id} />
+		</Admin>
+	);
+};
+export default Detail;

--- a/pages/calendar/salary-detail/[id].tsx
+++ b/pages/calendar/salary-detail/[id].tsx
@@ -1,7 +1,7 @@
 import { NextPage } from 'next';
 import { useRouter } from 'next/router';
 import ManageDetailScreen from 'src/app.features/calendar/screens/ManageDetailScreen';
-import WorkerScreen from 'src/app.features/calendar/screens/WorkerScreen';
+
 interface Props {
 	children: React.ReactElement | null;
 }

--- a/pages/calendar/salary.tsx
+++ b/pages/calendar/salary.tsx
@@ -9,7 +9,7 @@ interface Props {
 
 const isAdmin = (): boolean => {
 	// 점장 유효성 검사
-	return false;
+	return true;
 };
 
 const Admin: React.FC<Props> = ({ children }) => {

--- a/pages/calendar/salary.tsx
+++ b/pages/calendar/salary.tsx
@@ -1,0 +1,30 @@
+import type { NextPage } from 'next';
+import React from 'react';
+import ManagerScreen from 'src/app.features/calendar/screens/ManagerScreen';
+import WorkerScreen from 'src/app.features/calendar/screens/WorkerScreen';
+
+interface Props {
+	children: React.ReactElement | null;
+}
+
+const isAdmin = (): boolean => {
+	// 점장 유효성 검사
+	return false;
+};
+
+const Admin: React.FC<Props> = ({ children }) => {
+	if (!isAdmin()) {
+		return <WorkerScreen />;
+	}
+	return children;
+};
+
+const SalaryPage: NextPage = () => {
+	return (
+		<Admin>
+			<ManagerScreen />
+		</Admin>
+	);
+};
+
+export default SalaryPage;

--- a/pages/calendar/work-modify.tsx
+++ b/pages/calendar/work-modify.tsx
@@ -2,11 +2,7 @@ import type { NextPage } from 'next';
 import WorkModifyScreen from 'src/app.features/calendar/screens/WorkModifyScreen';
 
 const WorkModify: NextPage = () => {
-	return (
-		<div className="w-screen h-scree">
-			<WorkModifyScreen />
-		</div>
-	);
+	return <WorkModifyScreen />;
 };
 
 export default WorkModify;

--- a/src/app.components/CalendarButton.tsx
+++ b/src/app.components/CalendarButton.tsx
@@ -2,14 +2,14 @@ import React from 'react';
 
 interface Props {
 	// 2023.0.00 포맷으로 변경방법 -> const idx = transIdx(year, monthView, now)
-	idx: string; //ex 달력의 키값... 2023.2.11
+	idx: string; // ex 달력의 키값... 2023.2.11
 	day: number; // 1일, 2일, 3일... 일자
 	workDay: boolean; // 출근했던 날이면 true
 	toDay: string; // 금일 날짜 2023.2.11
-	ClickDay: string; // 클릭한 날짜 2023.2.11
+	clickDay: string; // 클릭한 날짜 2023.2.11
 }
 
-function CalendarButton({ idx, workDay, day, toDay, ClickDay }: Props) {
+function CalendarButton({ idx, workDay, day, toDay, clickDay }: Props) {
 	const getClassName = () => {
 		if (idx === toDay && workDay) {
 			return 'aria-pressed:bg-[#5696FC] aria-pressed:text-white text-[#5696FC] flex justify-center items-center w-[3rem] h-[3rem] bg-[#E8E8E8] border-solid border-[0.2rem] border-[#5696FC] rounded-lg';
@@ -19,13 +19,12 @@ function CalendarButton({ idx, workDay, day, toDay, ClickDay }: Props) {
 		}
 		if (workDay) {
 			return 'aria-pressed:bg-[#5696FC] aria-pressed:text-white flex justify-center items-center w-[3rem] h-[3rem] bg-[#E8E8E8] rounded-lg';
-		} else {
-			return 'aria-pressed:bg-[#5696FC] aria-pressed:text-white  flex justify-center items-center w-[3rem] h-[3rem] rounded-lg';
 		}
+		return 'aria-pressed:bg-[#5696FC] aria-pressed:text-white  flex justify-center items-center w-[3rem] h-[3rem] rounded-lg';
 	};
 
 	return (
-		<div key={idx} aria-pressed={idx === ClickDay} className={getClassName()}>
+		<div key={idx} aria-pressed={idx === clickDay} className={getClassName()}>
 			<span>{day}</span>
 		</div>
 	);

--- a/src/app.components/CalendarButton.tsx
+++ b/src/app.components/CalendarButton.tsx
@@ -1,0 +1,34 @@
+import React from 'react';
+
+interface Props {
+	// 2023.0.00 포맷으로 변경방법 -> const idx = transIdx(year, monthView, now)
+	idx: string; //ex 달력의 키값... 2023.2.11
+	day: number; // 1일, 2일, 3일... 일자
+	workDay: boolean; // 출근했던 날이면 true
+	toDay: string; // 금일 날짜 2023.2.11
+	ClickDay: string; // 클릭한 날짜 2023.2.11
+}
+
+function CalendarButton({ idx, workDay, day, toDay, ClickDay }: Props) {
+	const getClassName = () => {
+		if (idx === toDay && workDay) {
+			return 'aria-pressed:bg-[#5696FC] aria-pressed:text-white text-[#5696FC] flex justify-center items-center w-[3rem] h-[3rem] bg-[#E8E8E8] border-solid border-[0.2rem] border-[#5696FC] rounded-lg';
+		}
+		if (idx === toDay) {
+			return 'aria-pressed:bg-[#5696FC] aria-pressed:text-white text-[#5696FC] flex justify-center items-center w-[3rem] h-[3rem] border-solid border-[0.2rem] border-[#5696FC] rounded-lg';
+		}
+		if (workDay) {
+			return 'aria-pressed:bg-[#5696FC] aria-pressed:text-white flex justify-center items-center w-[3rem] h-[3rem] bg-[#E8E8E8] rounded-lg';
+		} else {
+			return 'aria-pressed:bg-[#5696FC] aria-pressed:text-white  flex justify-center items-center w-[3rem] h-[3rem] rounded-lg';
+		}
+	};
+
+	return (
+		<div key={idx} aria-pressed={idx === ClickDay} className={getClassName()}>
+			<span>{day}</span>
+		</div>
+	);
+}
+
+export default CalendarButton;

--- a/src/app.features/calendar/components/MakeCalendar.tsx
+++ b/src/app.features/calendar/components/MakeCalendar.tsx
@@ -1,11 +1,11 @@
 import React from 'react';
 import { transIdx } from 'src/app.modules/util/calendar';
+import CalendarButton from 'src/app.components/CalendarButton';
 import { IMakeCal } from '../types';
 import useStore from '../store';
-import CalendarButton from 'src/app.components/CalendarButton';
 
 function MakeCalendar({ year, monthView, firstDay, lastDate, schedule }: IMakeCal) {
-	const { toDay, ClickDay, modalIsOpen } = useStore();
+	const { toDay, clickDay, modalIsOpen } = useStore();
 	const days = [];
 
 	const makeDay = (week: number) => {
@@ -33,7 +33,7 @@ function MakeCalendar({ year, monthView, firstDay, lastDate, schedule }: IMakeCa
 					const workDay = schedule.includes(now);
 					result.push(
 						<button type="button" onClick={() => modalIsOpen(idx, workDay)} className="cursor-pointer" key={idx}>
-							<CalendarButton idx={idx} workDay={workDay} day={now} toDay={toDay} ClickDay={ClickDay} />
+							<CalendarButton idx={idx} workDay={workDay} day={now} toDay={toDay} clickDay={clickDay} />
 						</button>
 					);
 				}
@@ -50,7 +50,7 @@ function MakeCalendar({ year, monthView, firstDay, lastDate, schedule }: IMakeCa
 
 					result.push(
 						<button type="button" onClick={() => modalIsOpen(idx, workDay)} className="cursor-pointer" key={idx}>
-							<CalendarButton idx={idx} workDay={workDay} day={now} toDay={toDay} ClickDay={ClickDay} />
+							<CalendarButton idx={idx} workDay={workDay} day={now} toDay={toDay} clickDay={clickDay} />
 						</button>
 					);
 				}

--- a/src/app.features/calendar/components/MakeCalendar.tsx
+++ b/src/app.features/calendar/components/MakeCalendar.tsx
@@ -2,10 +2,12 @@ import React from 'react';
 import { transIdx } from 'src/app.modules/util/calendar';
 import { IMakeCal } from '../types';
 import useStore from '../store';
+import CalendarButton from 'src/app.components/CalendarButton';
 
 function MakeCalendar({ year, monthView, firstDay, lastDate, schedule }: IMakeCal) {
-	const { isDay, toDay, modalIsOpen } = useStore();
+	const { toDay, ClickDay, modalIsOpen } = useStore();
 	const days = [];
+
 	const makeDay = (week: number) => {
 		const result = [];
 		// 첫 주
@@ -29,52 +31,9 @@ function MakeCalendar({ year, monthView, firstDay, lastDate, schedule }: IMakeCa
 					// 첫주 날짜
 					const idx = transIdx(year, monthView, now);
 					const workDay = schedule.includes(now);
-					const data = [];
-					if (idx === toDay && workDay) {
-						data.push(
-							<span
-								key={idx}
-								aria-pressed={idx === isDay}
-								className="aria-pressed:bg-[#5696FC] aria-pressed:text-white text-[#5696FC] flex justify-center items-center w-[3rem] h-[3rem] bg-[#E8E8E8] border-solid border-[0.2rem] border-[#5696FC] rounded-lg"
-							>
-								{now}
-							</span>
-						);
-					} else if (idx === toDay) {
-						data.push(
-							<span
-								key={idx}
-								aria-pressed={idx === isDay}
-								className="aria-pressed:bg-[#5696FC] aria-pressed:text-white text-[#5696FC] flex justify-center items-center w-[3rem] h-[3rem] border-[0.2rem] border-solid border-[#5696FC] rounded-lg"
-							>
-								{now}
-							</span>
-						);
-					} else if (workDay) {
-						data.push(
-							<span
-								key={idx}
-								aria-pressed={idx === isDay}
-								className="aria-pressed:bg-[#5696FC] aria-pressed:text-white flex justify-center items-center w-[3rem] h-[3rem] bg-[#E8E8E8] rounded-lg"
-							>
-								{now}
-							</span>
-						);
-					} else {
-						data.push(
-							<span
-								key={idx}
-								aria-pressed={idx === isDay}
-								className="aria-pressed:bg-[#5696FC] aria-pressed:text-white  flex justify-center items-center w-[3rem] h-[3rem] rounded-lg"
-							>
-								{now}
-							</span>
-						);
-					}
-
 					result.push(
 						<button type="button" onClick={() => modalIsOpen(idx, workDay)} className="cursor-pointer" key={idx}>
-							{data}
+							<CalendarButton idx={idx} workDay={workDay} day={now} toDay={toDay} ClickDay={ClickDay} />
 						</button>
 					);
 				}
@@ -88,52 +47,10 @@ function MakeCalendar({ year, monthView, firstDay, lastDate, schedule }: IMakeCa
 					// 2주~4주차 날짜
 					const idx = transIdx(year, monthView, now);
 					const workDay = schedule.includes(now);
-					const data = [];
-					if (idx === toDay && workDay) {
-						data.push(
-							<span
-								key={idx}
-								aria-pressed={idx === isDay}
-								className="aria-pressed:bg-[#5696FC] aria-pressed:text-white text-[#5696FC] flex justify-center items-center w-[3rem] h-[3rem] bg-[#E8E8E8] border-solid border-[0.2rem] border-[#5696FC] rounded-lg"
-							>
-								{now}
-							</span>
-						);
-					} else if (idx === toDay) {
-						data.push(
-							<span
-								key={idx}
-								aria-pressed={idx === isDay}
-								className="aria-pressed:bg-[#5696FC] aria-pressed:text-white text-[#5696FC] flex justify-center items-center w-[3rem] h-[3rem] border-solid border-[0.2rem] border-[#5696FC] rounded-lg"
-							>
-								{now}
-							</span>
-						);
-					} else if (workDay) {
-						data.push(
-							<span
-								key={idx}
-								aria-pressed={idx === isDay}
-								className="aria-pressed:bg-[#5696FC] aria-pressed:text-white flex justify-center items-center w-[3rem] h-[3rem] bg-[#E8E8E8] rounded-lg"
-							>
-								{now}
-							</span>
-						);
-					} else {
-						data.push(
-							<span
-								key={idx}
-								aria-pressed={idx === isDay}
-								className="aria-pressed:bg-[#5696FC] aria-pressed:text-white  flex justify-center items-center w-[3rem] h-[3rem] rounded-lg"
-							>
-								{now}
-							</span>
-						);
-					}
 
 					result.push(
 						<button type="button" onClick={() => modalIsOpen(idx, workDay)} className="cursor-pointer" key={idx}>
-							{data}
+							<CalendarButton idx={idx} workDay={workDay} day={now} toDay={toDay} ClickDay={ClickDay} />
 						</button>
 					);
 				}

--- a/src/app.features/calendar/components/Modal.tsx
+++ b/src/app.features/calendar/components/Modal.tsx
@@ -15,20 +15,20 @@ interface Props {
 function Modal({ WorkMutate }: Props) {
 	const { toDay, workDay, modalIsClose, isDayReset } = useStore();
 	const [workTime, setWorkTime] = useState<string>('');
-	const { isDay } = useStore();
+	const { ClickDay } = useStore();
 	const router = useRouter();
 	const {
 		user: { startTime, endTime },
 		setTime,
 	} = useTimeSetStore();
 	const [openModalFlag, setOpenModalFlag] = useState<Flag>(null);
-	const [year, month, day] = isDay.split('.');
+	const [year, month, day] = ClickDay.split('.');
 	const [userName, setUserName] = useState([]);
 
 	useEffect(() => {
 		setOpenModalFlag(null);
 		return () => setUserName([]);
-	}, [isDay]);
+	}, [ClickDay]);
 
 	const timeHandler = (e: React.BaseSyntheticEvent) => {
 		const { name, value } = e.target;
@@ -47,8 +47,8 @@ function Modal({ WorkMutate }: Props) {
 	};
 
 	// 오늘 누른 경우
-	if (!workDay && isDay === toDay) {
-		const data = getToDay(getDayOfWeek(isDay));
+	if (!workDay && ClickDay === toDay) {
+		const data = getToDay(getDayOfWeek(ClickDay));
 		data.then((res) => {
 			// 여러번 요청감
 			if (res.data === '') {
@@ -60,7 +60,7 @@ function Modal({ WorkMutate }: Props) {
 	}
 
 	// 과거 누른 경우 & 출근한 날 누른 경우
-	if (workDay && new Date(isDay) <= new Date(toDay) && userName.length === 0) {
+	if (workDay && new Date(ClickDay) <= new Date(toDay) && userName.length === 0) {
 		const data = getWorkList({ year, month, day });
 		data.then((res) => {
 			setUserName(res.data.data);
@@ -74,7 +74,7 @@ function Modal({ WorkMutate }: Props) {
 
 	const renderContent = () => {
 		// 금일 클릭시
-		if (!workDay && isDay === toDay) {
+		if (!workDay && ClickDay === toDay) {
 			// 출근하기
 			return (
 				<div className="px-[2rem] py-[4rem] text-[2rem]">
@@ -119,13 +119,13 @@ function Modal({ WorkMutate }: Props) {
 			);
 		}
 
-		if (!workDay || new Date(isDay) > new Date(toDay)) {
+		if (!workDay || new Date(ClickDay) > new Date(toDay)) {
 			// 근무 안된 날짜 클릭시, 미래 클릭시
 			return (
 				<div className="px-[2rem] py-[4rem] text-[2rem]">
 					<div className="flex justify-between">
-						<div>{isDay}</div>
-						<div>{new Date(isDay) < new Date(toDay) && <button onClick={() => workModify()}>출근수정</button>}</div>
+						<div>{ClickDay}</div>
+						<div>{new Date(ClickDay) < new Date(toDay) && <button onClick={() => workModify()}>출근수정</button>}</div>
 					</div>
 					<div>아직 기록이 없어요.</div>
 				</div>
@@ -135,7 +135,7 @@ function Modal({ WorkMutate }: Props) {
 		return (
 			<div className="px-[2rem] py-[4rem] text-[2rem]">
 				<div className="flex justify-between">
-					<div>{isDay}</div>
+					<div>{ClickDay}</div>
 					<button onClick={() => workModify()}>출근수정</button>
 				</div>
 				<div>

--- a/src/app.features/calendar/components/Modal.tsx
+++ b/src/app.features/calendar/components/Modal.tsx
@@ -1,4 +1,3 @@
-import Link from 'next/link';
 import { useRouter } from 'next/router';
 import React, { useEffect, useState } from 'react';
 import SetTimeButtons from 'src/app.components/SetTimeButtons';

--- a/src/app.features/calendar/components/Modal.tsx
+++ b/src/app.features/calendar/components/Modal.tsx
@@ -151,7 +151,7 @@ function Modal({ WorkMutate }: Props) {
 	};
 
 	return (
-		<div className="z-10  bg-[#F8F8F8] w-screen  absolute bottom-0 flex-col items-center justify-center">
+		<div className="z-10 w-[46rem] bg-[#F8F8F8] absolute bottom-0 flex-col items-center justify-center">
 			<div className="flex justify-center mt-3">
 				<button type="button" onClick={() => modalIsClose()} className="w-[55px] h-[4px] bg-[#D9D9D9] rounded-lg">
 					{' '}

--- a/src/app.features/calendar/components/Modal.tsx
+++ b/src/app.features/calendar/components/Modal.tsx
@@ -126,7 +126,7 @@ function Modal({ WorkMutate }: Props) {
 				<div className="px-[2rem] py-[4rem] text-[2rem]">
 					<div className="flex justify-between">
 						<div>{isDay}</div>
-						<div>{new Date(isDay) < new Date(toDay) && '출근수정'}</div>
+						<div>{new Date(isDay) < new Date(toDay) && <button onClick={() => workModify()}>출근수정</button>}</div>
 					</div>
 					<div>아직 기록이 없어요.</div>
 				</div>

--- a/src/app.features/calendar/components/SalaryDetail.tsx
+++ b/src/app.features/calendar/components/SalaryDetail.tsx
@@ -1,0 +1,20 @@
+function SalaryDetail() {
+	return (
+		<div className="m-[2rem] p-[1.5rem] bg-[#F8F8FA] rounded-xl">
+			{[...new Array(4)].map((_data, index) => (
+				<div key={index} className="p-[0.5rem] my-[1rem]">
+					<div className="flex justify-between mb-[0.5rem]">
+						<span>1월 12일</span>
+						<span>300,000원</span>
+					</div>
+					<div className="flex justify-between">
+						<span>오전1:00~오후6:00</span>
+						<span>5시간</span>
+					</div>
+				</div>
+			))}
+		</div>
+	);
+}
+
+export default SalaryDetail;

--- a/src/app.features/calendar/components/TotalSalary.tsx
+++ b/src/app.features/calendar/components/TotalSalary.tsx
@@ -1,0 +1,10 @@
+function TotalSalary() {
+	return (
+		<div className="flex justify-between p-[2rem] bg-[#5377b1] rounded-lg">
+			<span>이번달 급여</span>
+			<span>800,000원</span>
+		</div>
+	);
+}
+
+export default TotalSalary;

--- a/src/app.features/calendar/screens/CalendarScreen.tsx
+++ b/src/app.features/calendar/screens/CalendarScreen.tsx
@@ -3,13 +3,13 @@ import SwiperCore from 'swiper';
 import { Swiper, SwiperSlide } from 'swiper/react';
 import 'swiper/css';
 import { useMutation, useQuery } from '@tanstack/react-query';
+import { SERVICE_URL } from 'src/app.modules/constants/ServiceUrl';
+import { useRouter } from 'next/router';
 import MakeCalendar from '../components/MakeCalendar';
 import { WEEK } from '../constants';
 import Modal from '../components/Modal';
 import useStore from '../store';
 import { getGray, postWork } from '../api';
-import { SERVICE_URL } from 'src/app.modules/constants/ServiceUrl';
-import { useRouter } from 'next/router';
 
 function CalendarScreen() {
 	// // 더미 스케쥴
@@ -116,8 +116,9 @@ function CalendarScreen() {
 								<span className="text-[2rem] font-bold mr-[0.5rem]">{`${year + fakeYear}.${monthView + 1}`}</span>
 								<div>버튼</div>
 							</div>
-							{/* calendarSalary */}
-							<div onClick={() => salary()}>급여</div>
+							<button type="button" onClick={() => salary()}>
+								급여
+							</button>
 						</div>
 						<div>
 							<div>

--- a/src/app.features/calendar/screens/CalendarScreen.tsx
+++ b/src/app.features/calendar/screens/CalendarScreen.tsx
@@ -14,14 +14,12 @@ import { useRouter } from 'next/router';
 function CalendarScreen() {
 	// // 더미 스케쥴
 	const [schedule, setSchedule] = useState<number[]>([]);
-	const { isOpen } = useStore();
-	const today = new Date();
+	const { isOpen, year, month, setCalendar } = useStore();
+
 	const [fakeYear, setFakeYear] = useState<number>(0);
-	const [calendar, setCalendar] = useState({ year: today.getFullYear(), month: today.getMonth() });
 
 	const router = useRouter();
 	// 년도, 달, 일정
-	const { year, month } = calendar;
 
 	// 해당 달의 첫날과 마지막날
 	const firstDay = Number(new Date(year, month, 1).getDay());
@@ -29,29 +27,18 @@ function CalendarScreen() {
 
 	const onChangeMonth = (swiper: SwiperCore) => {
 		// month와 monthView(스와이프) 동기화
-		setCalendar((prev) => ({
-			...prev,
-			month: swiper.realIndex,
-		}));
+		setCalendar(year, swiper.realIndex);
 
 		// 다음 슬라이드
 		if (swiper.swipeDirection === 'next') {
 			if (month === 11) {
-				setCalendar((prev) => ({
-					...prev,
-					month: 0,
-					year: year + 1,
-				}));
+				setCalendar(0, year + 1);
 			}
 		}
 		// 이전 슬라이드
 		if (swiper.swipeDirection === 'prev') {
 			if (month === 0) {
-				setCalendar((prev) => ({
-					...prev,
-					month: 11,
-					year: year - 1,
-				}));
+				setCalendar(11, year - 1);
 			}
 		}
 	};

--- a/src/app.features/calendar/screens/CalendarScreen.tsx
+++ b/src/app.features/calendar/screens/CalendarScreen.tsx
@@ -8,6 +8,8 @@ import { WEEK } from '../constants';
 import Modal from '../components/Modal';
 import useStore from '../store';
 import { getGray, postWork } from '../api';
+import { SERVICE_URL } from 'src/app.modules/constants/ServiceUrl';
+import { useRouter } from 'next/router';
 
 function CalendarScreen() {
 	// // 더미 스케쥴
@@ -16,6 +18,8 @@ function CalendarScreen() {
 	const today = new Date();
 	const [fakeYear, setFakeYear] = useState<number>(0);
 	const [calendar, setCalendar] = useState({ year: today.getFullYear(), month: today.getMonth() });
+
+	const router = useRouter();
 	// 년도, 달, 일정
 	const { year, month } = calendar;
 
@@ -76,6 +80,7 @@ function CalendarScreen() {
 		},
 		onError: (error) => alert('오류 발생.'),
 	});
+
 	const { data, refetch: getGrayRefetch } = useQuery(
 		['gray'],
 		() =>
@@ -96,6 +101,10 @@ function CalendarScreen() {
 	useEffect(() => {
 		getGrayRefetch();
 	}, [month, getGrayRefetch, WorkData]);
+
+	const salary = () => {
+		router.push(`${SERVICE_URL.calendarSalary}`);
+	};
 	return (
 		<div>
 			<Swiper
@@ -120,7 +129,8 @@ function CalendarScreen() {
 								<span className="text-[2rem] font-bold mr-[0.5rem]">{`${year + fakeYear}.${monthView + 1}`}</span>
 								<div>버튼</div>
 							</div>
-							<div>아이콘</div>
+							{/* calendarSalary */}
+							<div onClick={() => salary()}>급여</div>
 						</div>
 						<div>
 							<div>

--- a/src/app.features/calendar/screens/ManageDetailScreen.tsx
+++ b/src/app.features/calendar/screens/ManageDetailScreen.tsx
@@ -1,0 +1,25 @@
+import SalaryDetail from '../components/SalaryDetail';
+import TotalSalary from '../components/TotalSalary';
+
+function ManageDetailScreen({ id }: { id: string | string[] | undefined }) {
+	// 급여 상세페이지
+	return (
+		<div className="text-[1.5rem]">
+			<div className="text-white bg-[#5696FC] p-[2rem]">
+				<div>
+					<div>최영진 알바생</div>
+					<div>
+						<span>화(9:00-12:00)</span>
+						<span>토(9:00-12:00)</span>
+					</div>
+				</div>
+				<TotalSalary />
+			</div>
+			<div>
+				<SalaryDetail />
+			</div>
+		</div>
+	);
+}
+
+export default ManageDetailScreen;

--- a/src/app.features/calendar/screens/ManagerScreen.tsx
+++ b/src/app.features/calendar/screens/ManagerScreen.tsx
@@ -1,5 +1,46 @@
+import SalaryDetail from '../components/SalaryDetail';
+import useStore from '../store';
+
 function ManagerScreen() {
-	return <div>점장 급여 페이지</div>;
+	//점장 급여 페이지
+	const { year, month } = useStore();
+	return (
+		<div className="text-[1.5rem]">
+			<div className="text-center p-[0.2rem]">
+				<div className="p-[0.5rem]">
+					{year} {month + 1}월
+				</div>
+			</div>
+			<div>
+				<div className="mb-[4rem]">
+					<div>매니저</div>
+					<div className="flex justify-between bg-[#F8F8FA] p-[2rem]">
+						<div className="flex">
+							<div>
+								<div>최영진</div>
+								<div>1.1~1.31</div>
+							</div>
+						</div>
+						<div>1,067,000원 {'>'}</div>
+					</div>
+				</div>
+				<div>
+					<div>알바생</div>
+					{[...new Array(4)].map((_data, index) => (
+						<div key={index} className="flex justify-between bg-[#F8F8FA] p-[2rem] my-[1rem]">
+							<div className="flex">
+								<div>
+									<div>최영진</div>
+									<div>1.1~1.31</div>
+								</div>
+							</div>
+							<div>1,067,000원 {'>'}</div>
+						</div>
+					))}
+				</div>
+			</div>
+		</div>
+	);
 }
 
 export default ManagerScreen;

--- a/src/app.features/calendar/screens/ManagerScreen.tsx
+++ b/src/app.features/calendar/screens/ManagerScreen.tsx
@@ -3,7 +3,7 @@ import { SERVICE_URL } from 'src/app.modules/constants/ServiceUrl';
 import useStore from '../store';
 
 function ManagerScreen() {
-	//점장 급여 페이지
+	// 점장 급여 페이지
 	const { year, month } = useStore();
 	const router = useRouter();
 	return (
@@ -16,34 +16,37 @@ function ManagerScreen() {
 			<div>
 				<div className="mb-[4rem]">
 					<div>매니저</div>
-					<div
-						onClick={() => router.push(`${SERVICE_URL.calendarSalaryDetail}/${99}`)}
-						className="flex justify-between items-center bg-[#F8F8FA] p-[2rem] my-[1rem] rounded-xl"
-					>
+					<div className="flex justify-between items-center bg-[#F8F8FA] p-[2rem] my-[1rem] rounded-xl">
 						<div className="flex">
 							<div>
 								<div>최영진</div>
 								<div>1.1~1.31</div>
 							</div>
 						</div>
-						<div>1,067,000원 {'>'}</div>
+						<div>
+							1,067,000원{' '}
+							<button type="button" onClick={() => router.push(`${SERVICE_URL.calendarSalaryDetail}/${99}`)}>
+								{'>'}
+							</button>
+						</div>
 					</div>
 				</div>
 				<div>
 					<div>알바생</div>
 					{[...new Array(4)].map((_data, index) => (
-						<div
-							onClick={() => router.push(`${SERVICE_URL.calendarSalaryDetail}/${index}`)}
-							key={index}
-							className="flex justify-between items-center bg-[#F8F8FA] p-[2rem] my-[1rem] rounded-xl"
-						>
+						<div key={index} className="flex justify-between items-center bg-[#F8F8FA] p-[2rem] my-[1rem] rounded-xl">
 							<div className="flex">
 								<div>
 									<div>최영진</div>
 									<div>1.1~1.31</div>
 								</div>
 							</div>
-							<div>1,067,000원 {'>'}</div>
+							<div>
+								1,067,000원{' '}
+								<button type="button" onClick={() => router.push(`${SERVICE_URL.calendarSalaryDetail}/${index}`)}>
+									{'>'}
+								</button>
+							</div>
 						</div>
 					))}
 				</div>

--- a/src/app.features/calendar/screens/ManagerScreen.tsx
+++ b/src/app.features/calendar/screens/ManagerScreen.tsx
@@ -1,0 +1,5 @@
+function ManagerScreen() {
+	return <div>점장 급여 페이지</div>;
+}
+
+export default ManagerScreen;

--- a/src/app.features/calendar/screens/ManagerScreen.tsx
+++ b/src/app.features/calendar/screens/ManagerScreen.tsx
@@ -1,9 +1,11 @@
-import SalaryDetail from '../components/SalaryDetail';
+import { useRouter } from 'next/router';
+import { SERVICE_URL } from 'src/app.modules/constants/ServiceUrl';
 import useStore from '../store';
 
 function ManagerScreen() {
 	//점장 급여 페이지
 	const { year, month } = useStore();
+	const router = useRouter();
 	return (
 		<div className="text-[1.5rem]">
 			<div className="text-center p-[0.2rem]">
@@ -14,7 +16,10 @@ function ManagerScreen() {
 			<div>
 				<div className="mb-[4rem]">
 					<div>매니저</div>
-					<div className="flex justify-between bg-[#F8F8FA] p-[2rem]">
+					<div
+						onClick={() => router.push(`${SERVICE_URL.calendarSalaryDetail}/${99}`)}
+						className="flex justify-between items-center bg-[#F8F8FA] p-[2rem] my-[1rem] rounded-xl"
+					>
 						<div className="flex">
 							<div>
 								<div>최영진</div>
@@ -27,7 +32,11 @@ function ManagerScreen() {
 				<div>
 					<div>알바생</div>
 					{[...new Array(4)].map((_data, index) => (
-						<div key={index} className="flex justify-between bg-[#F8F8FA] p-[2rem] my-[1rem]">
+						<div
+							onClick={() => router.push(`${SERVICE_URL.calendarSalaryDetail}/${index}`)}
+							key={index}
+							className="flex justify-between items-center bg-[#F8F8FA] p-[2rem] my-[1rem] rounded-xl"
+						>
 							<div className="flex">
 								<div>
 									<div>최영진</div>

--- a/src/app.features/calendar/screens/WorkModifyScreen.tsx
+++ b/src/app.features/calendar/screens/WorkModifyScreen.tsx
@@ -9,8 +9,8 @@ import useStore from '../store';
 type Flag = 'startTime' | 'endTime' | null;
 function WorkModifyScreen() {
 	const [workTime, setWorkTime] = useState<string | undefined>('');
-	const { isDay, toDay, workDay, isDayReset } = useStore();
-	const [year, month, day] = isDay.split('.');
+	const { clickDay, toDay, workDay, isDayReset } = useStore();
+	const [year, month, day] = clickDay.split('.');
 	const router = useRouter();
 	const {
 		user: { startTime, endTime },
@@ -60,16 +60,16 @@ function WorkModifyScreen() {
 
 	// 수정 버튼
 	const modifyBtn = () => {
-		const wrkTimeData = getWorkTimeString();
-		const [start, end] = wrkTimeData.split('~');
+		const workTimeData = getWorkTimeString();
+		const [start, end] = workTimeData.split('~');
 		const startSplit = Number(start.split(':')[0]) * 60 + Number(start.split(':')[1]);
 		const endSplit = Number(end.split(':')[0]) * 60 + Number(end.split(':')[1]);
 		const timeDiff = Math.abs((startSplit - endSplit) / 60);
-		if (!workDay && new Date(isDay) < new Date(toDay)) {
+		if (!workDay && new Date(clickDay) < new Date(toDay)) {
 			// 출근하기
-			WorkMutate({ year, month, day, workTime: wrkTimeData, workHour: timeDiff });
+			WorkMutate({ year, month, day, workTime: workTimeData, workHour: timeDiff });
 		} else {
-			mutate({ year, month, day, workTime: wrkTimeData, workHour: timeDiff });
+			mutate({ year, month, day, workTime: workTimeData, workHour: timeDiff });
 		}
 
 		isDayReset();

--- a/src/app.features/calendar/screens/WorkerScreen.tsx
+++ b/src/app.features/calendar/screens/WorkerScreen.tsx
@@ -1,4 +1,5 @@
 import SalaryDetail from '../components/SalaryDetail';
+import TotalSalary from '../components/TotalSalary';
 import useStore from '../store';
 
 function WorkerScreen() {
@@ -10,10 +11,7 @@ function WorkerScreen() {
 				<div className="p-[0.5rem]">
 					{year} {month + 1}월
 				</div>
-				<div className="flex justify-between p-[2rem] m-[2rem] bg-[#5377b1] rounded-lg">
-					<span>이번달 급여</span>
-					<span>800,000원</span>
-				</div>
+				<TotalSalary />
 			</div>
 			<div>
 				<SalaryDetail />

--- a/src/app.features/calendar/screens/WorkerScreen.tsx
+++ b/src/app.features/calendar/screens/WorkerScreen.tsx
@@ -1,5 +1,25 @@
+import SalaryDetail from '../components/SalaryDetail';
+import useStore from '../store';
+
 function WorkerScreen() {
-	return <div>직원 급여 페이지</div>;
+	//직원 급여 페이지
+	const { year, month } = useStore();
+	return (
+		<div className="text-[1.5rem]">
+			<div className="text-center text-white bg-[#5696FC] p-[0.2rem]">
+				<div className="p-[0.5rem]">
+					{year} {month + 1}월
+				</div>
+				<div className="flex justify-between p-[2rem] m-[2rem] bg-[#5377b1] rounded-lg">
+					<span>이번달 급여</span>
+					<span>800,000원</span>
+				</div>
+			</div>
+			<div>
+				<SalaryDetail />
+			</div>
+		</div>
+	);
 }
 
 export default WorkerScreen;

--- a/src/app.features/calendar/screens/WorkerScreen.tsx
+++ b/src/app.features/calendar/screens/WorkerScreen.tsx
@@ -3,7 +3,7 @@ import TotalSalary from '../components/TotalSalary';
 import useStore from '../store';
 
 function WorkerScreen() {
-	//직원 급여 페이지
+	// 직원 급여 페이지
 	const { year, month } = useStore();
 	return (
 		<div className="text-[1.5rem]">

--- a/src/app.features/calendar/screens/WorkerScreen.tsx
+++ b/src/app.features/calendar/screens/WorkerScreen.tsx
@@ -1,0 +1,5 @@
+function WorkerScreen() {
+	return <div>직원 급여 페이지</div>;
+}
+
+export default WorkerScreen;

--- a/src/app.features/calendar/store/index.ts
+++ b/src/app.features/calendar/store/index.ts
@@ -5,10 +5,10 @@ interface IStore {
 	year: number;
 	month: number;
 	isOpen: boolean;
-	isDay: string;
+	ClickDay: string;
 	toDay: string;
 	workDay: boolean;
-	modalIsOpen: (isDay: string, workDay: boolean) => void;
+	modalIsOpen: (ClickDay: string, workDay: boolean) => void;
 	modalIsClose: () => void;
 	isDayReset: () => void;
 	setCalendar: (year: number, month: number) => void;
@@ -18,12 +18,12 @@ const useStore = create<IStore>((set) => ({
 	year: today.getFullYear(),
 	month: today.getMonth(),
 	isOpen: false,
-	isDay: '',
+	ClickDay: '',
 	toDay: transIdx(today.getFullYear(), today.getMonth(), today.getDate()),
 	workDay: false,
-	modalIsOpen: (isDay, workDay) => set(() => ({ isOpen: true, isDay, workDay })),
+	modalIsOpen: (ClickDay, workDay) => set(() => ({ isOpen: true, ClickDay, workDay })),
 	modalIsClose: () => set(() => ({ isOpen: false })),
-	isDayReset: () => set(() => ({ isDay: '' })),
+	isDayReset: () => set(() => ({ ClickDay: '' })),
 	setCalendar: (year, month) => set(() => ({ year, month })),
 }));
 

--- a/src/app.features/calendar/store/index.ts
+++ b/src/app.features/calendar/store/index.ts
@@ -5,10 +5,10 @@ interface IStore {
 	year: number;
 	month: number;
 	isOpen: boolean;
-	ClickDay: string;
+	clickDay: string;
 	toDay: string;
 	workDay: boolean;
-	modalIsOpen: (ClickDay: string, workDay: boolean) => void;
+	modalIsOpen: (clickDay: string, workDay: boolean) => void;
 	modalIsClose: () => void;
 	isDayReset: () => void;
 	setCalendar: (year: number, month: number) => void;
@@ -18,12 +18,12 @@ const useStore = create<IStore>((set) => ({
 	year: today.getFullYear(),
 	month: today.getMonth(),
 	isOpen: false,
-	ClickDay: '',
+	clickDay: '',
 	toDay: transIdx(today.getFullYear(), today.getMonth(), today.getDate()),
 	workDay: false,
-	modalIsOpen: (ClickDay, workDay) => set(() => ({ isOpen: true, ClickDay, workDay })),
+	modalIsOpen: (clickDay, workDay) => set(() => ({ isOpen: true, clickDay, workDay })),
 	modalIsClose: () => set(() => ({ isOpen: false })),
-	isDayReset: () => set(() => ({ ClickDay: '' })),
+	isDayReset: () => set(() => ({ clickDay: '' })),
 	setCalendar: (year, month) => set(() => ({ year, month })),
 }));
 

--- a/src/app.features/calendar/store/index.ts
+++ b/src/app.features/calendar/store/index.ts
@@ -2,6 +2,8 @@ import { transIdx } from 'src/app.modules/util/calendar';
 import create from 'zustand';
 
 interface IStore {
+	year: number;
+	month: number;
 	isOpen: boolean;
 	isDay: string;
 	toDay: string;
@@ -9,16 +11,20 @@ interface IStore {
 	modalIsOpen: (isDay: string, workDay: boolean) => void;
 	modalIsClose: () => void;
 	isDayReset: () => void;
+	setCalendar: (year: number, month: number) => void;
 }
-
+const today = new Date();
 const useStore = create<IStore>((set) => ({
+	year: today.getFullYear(),
+	month: today.getMonth(),
 	isOpen: false,
 	isDay: '',
-	toDay: transIdx(new Date().getFullYear(), new Date().getMonth(), new Date().getDate()),
+	toDay: transIdx(today.getFullYear(), today.getMonth(), today.getDate()),
 	workDay: false,
 	modalIsOpen: (isDay, workDay) => set(() => ({ isOpen: true, isDay, workDay })),
 	modalIsClose: () => set(() => ({ isOpen: false })),
 	isDayReset: () => set(() => ({ isDay: '' })),
+	setCalendar: (year, month) => set(() => ({ year, month })),
 }));
 
 export default useStore;

--- a/src/app.modules/constants/ServiceUrl.ts
+++ b/src/app.modules/constants/ServiceUrl.ts
@@ -8,4 +8,5 @@ export const SERVICE_URL = {
 	countBag: '/count/standard-plastic-bag',
 	calendar: '/calendar',
 	calendarModify: '/calendar/work-modify',
+	calendarSalary: '/calendar/salary',
 };

--- a/src/app.modules/constants/ServiceUrl.ts
+++ b/src/app.modules/constants/ServiceUrl.ts
@@ -9,4 +9,5 @@ export const SERVICE_URL = {
 	calendar: '/calendar',
 	calendarModify: '/calendar/work-modify',
 	calendarSalary: '/calendar/salary',
+	calendarSalaryDetail: '/calendar/salary-detail',
 };

--- a/src/app.modules/util/calendar.ts
+++ b/src/app.modules/util/calendar.ts
@@ -8,16 +8,3 @@ export const getDayOfWeek = (data: string) => {
 	const dayOfWeek = WEEK_ENG[new Date(data).getDay()];
 	return dayOfWeek;
 };
-
-// export const getScheduleMatch = (schedule: { [x: string]: object | string }, idx: string) => {
-// 	let arr = '';
-// 	Object.keys(schedule).forEach((key) => {
-// 		const data = Object.keys(schedule[key]);
-// 		for (let i = 0; i < data.length; i += 1) {
-// 			if (data[i] === getDayOfWeek(idx)) {
-// 				arr = key;
-// 			}
-// 		}
-// 	});
-// 	return arr;
-// };


### PR DESCRIPTION
## PR 타입 (하나 이상의 PR 타입 선택)

- [v] 기능 추가
- [] 기능 수정
- [] 기능 삭제
- [v] 버그 수정
- [] 의존성, 환경 변수, 빌드 관련 코드 업데이트
- [] 문서 수정 (ex. README)

## 반영 브랜치

- feature/calendar -> main

## 변경 사항

- 출근하기에서 일하는 요일 구분해서 시간 설정하는 로직 버그 수정
- 급여 페이지(직원, 점장) UX
- 점장의 급여 상세보기 페이지 UX
- 캘린더 버튼 내부 컴포넌트화

## 유의 사항

- 캘린더 버튼 컴포넌트화된 것은 버튼이 아니라 내부 콘텐츠인 CSS이므로 아래 예시와 같이 사용해야 한다. (css 색상은 아직 테마 색상으로 지정 안함)
- 컴포넌트 위치는 src/app.components/CalendarButton.tsx

### 컴포넌트 구현 내용
<img width="382" alt="스크린샷 2023-02-13 오후 1 04 30" src="https://user-images.githubusercontent.com/77488652/218367952-fff512fa-9d18-4da2-8017-8f3d41c76b0f.png">

### 예시
src/app.features/caelndar/components/MakeCalendar.tsx
```
<button type="button" onClick={() => modalIsOpen(idx, workDay)} className="cursor-pointer" key={idx}>
    <CalendarButton idx={idx} workDay={workDay} day={now} toDay={toDay} ClickDay={ClickDay} />
</button>
```

### props 요소
체크리스트에 이 컴포넌트가 잘 적용될지 몰라 일단 props를 최대한 많이 넣었음. 추후 확인후 수정 및 리팩터링 예정.

#### * 2023.1.11 포맷으로 변경방법 -> transIdx(year, month, day)
- idx -> 달력 그릴때 year, month, day를 가지고 그리는데 그걸 `transIdx`로 키값화 한 것
- workDay -> 출근했던 날인지 여부 boolean (체크리스트 경우 체크한 날?)
- toDay -> 금일 날짜 (transIdx 사용)
- ClickDay -> 클릭한 날짜 (transIdx 사용)
- day -> 1, 2 ,3... 과 같은 일자 (위 사진의 18과 같은)


