### PR TITLE
feat: 기본 버튼 컴포넌트

### DIFF
--- a/src/app.components/Button/NomalButton.tsx
+++ b/src/app.components/Button/NomalButton.tsx
@@ -1,0 +1,28 @@
+import React from 'react';
+
+interface Props {
+	title: string;
+	bgColor: string;
+	titleColor: string;
+	ClickFn?: () => void;
+	disabled?: boolean;
+}
+
+function NomalButton({ title, titleColor, bgColor, ClickFn, disabled = false }: Props) {
+	return (
+		<button
+			onClick={() => {
+				if (ClickFn) {
+					ClickFn();
+				}
+			}}
+			disabled={disabled}
+			type="button"
+			className={`${bgColor} ${titleColor} w-full h-[6rem] rounded-[0.8rem] text-subhead4`}
+		>
+			{title}
+		</button>
+	);
+}
+
+export default NomalButton;

--- a/src/app.features/calendar/components/Keypad.tsx
+++ b/src/app.features/calendar/components/Keypad.tsx
@@ -1,4 +1,5 @@
 import React, { useState } from 'react';
+import NomalButton from 'src/app.components/Button/NomalButton';
 import KeypadDelIcon from 'src/app.modules/assets/calendar/keypadDel.svg';
 import useModalStore from 'src/app.modules/store/modal';
 import useStore from '../store';
@@ -94,17 +95,17 @@ function Keypad({ year, month }: Props) {
 				))}
 			</div>
 			<div className="mt-[-0.7rem]">
-				<button
-					type="button"
-					onClick={() => {
+				<NomalButton
+					title="이동"
+					bgColor={`${keypadYear === '' && keypadMonth === '' ? 'bg-g2' : 'bg-primary'} `}
+					titleColor={`${keypadYear === '' && keypadMonth === '' ? 'text-g7' : 'text-w'} `}
+					ClickFn={() => {
 						setCalendar(Number(keypadYear), Number(keypadMonth) - 1);
 						keypadChange();
 						modalIsClose();
 					}}
-					className={`${(keypadYear || keypadMonth) && 'bg-primary'} bg-g2 w-full h-[6rem] rounded-[0.8rem]`}
-				>
-					<span className={`text-g7 text-subhead4 ${(keypadYear || keypadMonth) && 'text-w'} `}>이동</span>
-				</button>
+					disabled={keypadYear === '' && keypadMonth === ''}
+				/>
 			</div>
 		</div>
 	);

--- a/src/app.features/calendar/components/Modal.tsx
+++ b/src/app.features/calendar/components/Modal.tsx
@@ -6,6 +6,7 @@ import { SERVICE_URL } from 'src/app.modules/constants/ServiceUrl';
 import useModalStore from 'src/app.modules/store/modal';
 import { getDayOfWeek } from 'src/app.modules/util/calendar';
 import ProfileImage from 'src/app.components/ProfileImage';
+import NomalButton from 'src/app.components/Button/NomalButton';
 import { getToDay, getWorkList, MutateBody } from '../api';
 import useStore from '../store';
 import useTimeSetStore from '../store/time';
@@ -87,7 +88,6 @@ function Modal({ WorkMutate }: Props) {
 		modalIsClose();
 		router.push(`${SERVICE_URL.calendarModify}`);
 	};
-
 	const renderContent = () => {
 		if (clickDay === 'keypad') {
 			return <Keypad year={year} month={month} />;
@@ -130,13 +130,13 @@ function Modal({ WorkMutate }: Props) {
 						</div>
 					)}
 					<div>
-						<button
-							type="button"
-							className="bg-primary w-full h-[6rem] text-w rounded-[0.8rem] text-subhead4"
-							onClick={() => commute()}
-						>
-							출근하기
-						</button>
+						<NomalButton
+							bgColor={`${workTime !== '' || getWorkTimeString() !== '01:00~01:00' ? 'bg-primary' : 'bg-g3'}`}
+							titleColor={`${workTime !== '' || getWorkTimeString() !== '01:00~01:00' ? 'text-w' : 'text-g7'}`}
+							ClickFn={() => commute()}
+							title="출근하기"
+							disabled={workTime === '' || getWorkTimeString() === '01:00~01:00'}
+						/>
 					</div>
 				</div>
 			);

--- a/src/app.features/calendar/screens/WorkModifyScreen.tsx
+++ b/src/app.features/calendar/screens/WorkModifyScreen.tsx
@@ -7,6 +7,7 @@ import Overlay from 'src/app.components/Modal/Overlay';
 import useModalStore from 'src/app.modules/store/modal';
 import Header from 'src/app.components/Header';
 import DelIcon from 'src/app.modules/assets/calendar/delete.svg';
+import NomalButton from 'src/app.components/Button/NomalButton';
 import useTimeSetStore from '../store/time';
 import { delWorkModify, postWork, putWorkModify } from '../api';
 import useStore from '../store';
@@ -136,13 +137,14 @@ function WorkModifyScreen() {
 				</div>
 
 				<div className="mb-[2rem]">
-					<button
-						type="button"
-						className="bg-g2 w-full h-[6rem] text-w rounded-[0.8rem] text-subhead4"
-						onClick={() => modifyBtn()}
-					>
-						<span className="text-g7">수정</span>
-					</button>
+					<NomalButton
+						title="수정"
+						bgColor="bg-g2"
+						titleColor="text-g7"
+						ClickFn={() => {
+							modifyBtn();
+						}}
+					/>
 				</div>
 			</div>
 			{isModalOpen && (


### PR DESCRIPTION
## PR 타입 (하나 이상의 PR 타입 선택)

- [v] 기능 추가
- [] 기능 수정
- [] 기능 삭제
- [] 버그 수정
- [] 의존성, 환경 변수, 빌드 관련 코드 업데이트
- [] 문서 수정 (ex. README)

## 반영 브랜치

- feature/calendar -> main

## 변경 사항

- 기본 버튼 컴포넌트 추가
- 위치 : src/app.components/Button/NomalButton.tsx

## 사용법
### props
interface Props {
	title: string;
	bgColor: string;
	titleColor: string;
	ClickFn?: () => void;
	disabled?: boolean;
}

### 예시 코드
예시 코드는 src/app.feautres/calendar/components/Keyapd.tsx 를 참고

![123](https://user-images.githubusercontent.com/77488652/219845518-a9e49a8b-3797-4b9f-b1e5-c86946dcdcba.png)


## 유의 사항

- disabled로 활성화, 비활성화 색상 지정하고 싶었으나, 카카오 로그인 버튼과 회원가입 마지막 버튼의 색상이 달라 일단 사용자가 지정하도록 함
