### PR TITLE
fix: 기본 버튼 컴포넌트 로직 변경

### DIFF
--- a/src/app.components/Button/NomalButton.tsx
+++ b/src/app.components/Button/NomalButton.tsx
@@ -2,13 +2,21 @@ import React from 'react';
 
 interface Props {
 	title: string;
-	bgColor: string;
-	titleColor: string;
+	bgColor?: string;
+	titleColor?: string;
 	ClickFn?: () => void;
 	disabled?: boolean;
 }
 
 function NomalButton({ title, titleColor, bgColor, ClickFn, disabled = false }: Props) {
+	console.log(titleColor !== undefined && bgColor !== undefined);
+	const className = () => {
+		if (titleColor !== undefined && bgColor !== undefined) {
+			return `${titleColor} ${bgColor}`;
+		}
+		return `${disabled ? 'bg-g2 text-g7' : 'bg-primary text-w'}`;
+	};
+
 	return (
 		<button
 			onClick={() => {
@@ -18,7 +26,7 @@ function NomalButton({ title, titleColor, bgColor, ClickFn, disabled = false }: 
 			}}
 			disabled={disabled}
 			type="button"
-			className={`${bgColor} ${titleColor} w-full h-[6rem] rounded-[0.8rem] text-subhead4`}
+			className={`${className()} w-full h-[6rem] rounded-[0.8rem] text-subhead4`}
 		>
 			{title}
 		</button>

--- a/src/app.components/Button/NomalButton.tsx
+++ b/src/app.components/Button/NomalButton.tsx
@@ -9,7 +9,6 @@ interface Props {
 }
 
 function NomalButton({ title, titleColor, bgColor, ClickFn, disabled = false }: Props) {
-	console.log(titleColor !== undefined && bgColor !== undefined);
 	const className = () => {
 		if (titleColor !== undefined && bgColor !== undefined) {
 			return `${titleColor} ${bgColor}`;

--- a/src/app.features/calendar/components/Keypad.tsx
+++ b/src/app.features/calendar/components/Keypad.tsx
@@ -97,14 +97,12 @@ function Keypad({ year, month }: Props) {
 			<div className="mt-[-0.7rem]">
 				<NomalButton
 					title="이동"
-					bgColor={`${keypadYear === '' && keypadMonth === '' ? 'bg-g2' : 'bg-primary'} `}
-					titleColor={`${keypadYear === '' && keypadMonth === '' ? 'text-g7' : 'text-w'} `}
 					ClickFn={() => {
 						setCalendar(Number(keypadYear), Number(keypadMonth) - 1);
 						keypadChange();
 						modalIsClose();
 					}}
-					disabled={keypadYear === '' && keypadMonth === ''}
+					disabled={keypadYear === '' || keypadMonth === ''}
 				/>
 			</div>
 		</div>

--- a/src/app.features/calendar/components/Modal.tsx
+++ b/src/app.features/calendar/components/Modal.tsx
@@ -131,11 +131,9 @@ function Modal({ WorkMutate }: Props) {
 					)}
 					<div>
 						<NomalButton
-							bgColor={`${workTime !== '' || getWorkTimeString() !== '01:00~01:00' ? 'bg-primary' : 'bg-g3'}`}
-							titleColor={`${workTime !== '' || getWorkTimeString() !== '01:00~01:00' ? 'text-w' : 'text-g7'}`}
 							ClickFn={() => commute()}
 							title="출근하기"
-							disabled={workTime === '' || getWorkTimeString() === '01:00~01:00'}
+							disabled={workTime === '' && getWorkTimeString() === '01:00~01:00'}
 						/>
 					</div>
 				</div>


### PR DESCRIPTION
## PR 타입 (하나 이상의 PR 타입 선택)

- [] 기능 추가
- [] 기능 수정
- [] 기능 삭제
- [] 버그 수정
- [] 의존성, 환경 변수, 빌드 관련 코드 업데이트
- [] 문서 수정 (ex. README)

## 반영 브랜치

- feature/calendar -> main

## 변경 사항

- 기본 버튼 컴포넌트 로직 변경
- 위치 : src/app.components/Button/NomalButton.tsx

## 사용법
### props
	title: string;
	bgColor?: string;
	titleColor?: string;
	ClickFn?: () => void;
	disabled?: boolean;

### 예시 코드
예시 코드는 src/app.feautres/calendar/components/Keyapd.tsx 를 참고

```
<NomalButton
	title="이동"
	ClickFn={() => {
		setCalendar(Number(keypadYear), Number(keypadMonth) - 1);
		keypadChange();
		modalIsClose();
	}}
	disabled={keypadYear === '' || keypadMonth === ''}
/>;
```


## 유의 사항

- disabled로 활성화, 비활성화와 더불어 색상까지 자동 변경, 버튼 색상이 다른 카카오 로그인 버튼이나 회원가입 마치기 버튼은 bgColor와 titleColor를 따로 지정해준다.