### PR TITLE
Feature/calendar

### DIFF
--- a/pages/calendar/salary.tsx
+++ b/pages/calendar/salary.tsx
@@ -13,7 +13,7 @@ interface Props {
 export const Admin: React.FC<Props> = ({ children, data, type = '' }) => {
 	if (data !== 'MANAGER') {
 		return (
-			<div className="h-[100vh]">
+			<div className="min-h-[100vh]">
 				<WorkerScreen />
 			</div>
 		);
@@ -25,7 +25,7 @@ const SalaryPage: NextPage = () => {
 	const { data, isLoading } = useUser();
 
 	return (
-		<div className="h-[100vh] mx-auto relative w-full">
+		<div className="min-h-[100vh] mx-auto relative w-full">
 			{!isLoading && (
 				<Admin data={data.role} type="detail">
 					<ManagerScreen />

--- a/pages/calendar/work-record/[id].tsx
+++ b/pages/calendar/work-record/[id].tsx
@@ -22,7 +22,7 @@ const WorkRecord: NextPage = () => {
 	// 수정하기
 	const { mutate: ModifyMutate } = useMutation(putWorkModify, {
 		onSuccess: (res) => {
-			console.log(res);
+			// console.log(res);
 			router.back();
 		},
 		onError: (error) => console.log(error),

--- a/src/app.components/Modal/Overlay.tsx
+++ b/src/app.components/Modal/Overlay.tsx
@@ -12,7 +12,11 @@ function Overlay({ children, bgColor = 'bg-transparent-30%', blur = false, overl
 
 	useEffect(() => {
 		setIsAnimating(true);
-		return () => setIsAnimating(false);
+		document.body.style.overflow = 'hidden';
+		return () => {
+			setIsAnimating(false);
+			document.body.style.overflow = 'unset';
+		};
 	}, []);
 
 	return (
@@ -27,7 +31,7 @@ function Overlay({ children, bgColor = 'bg-transparent-30%', blur = false, overl
 						overlayClickFn();
 					}
 				}}
-				className={`translate-x-0 z-[101]  fixed max-w-[50rem] mx-auto top-0 left-0 bottom-0 right-0 ${bgColor} ${
+				className={`translate-x-0 z-[101] fixed max-w-[50rem] mx-auto top-0 left-0 bottom-0 right-0 ${bgColor} ${
 					blur && 'backdrop-filter backdrop-blur-[0.4rem]'
 				}  ${
 					!children.props.yesFn &&

--- a/src/app.components/app.base/Button/Bar.tsx
+++ b/src/app.components/app.base/Button/Bar.tsx
@@ -21,10 +21,10 @@ function Bar({
 }: Props) {
 	const className = () => {
 		if (mode === 'wide') {
-			return 'fixed max-w-[42rem] mx-auto inset-x-0 bottom-0';
+			return 'fixed max-w-[50rem] mx-auto inset-x-0 bottom-0';
 		}
 		if (mode === 'wide2') {
-			return 'h-[8rem] fixed max-w-[42rem] mx-auto inset-x-0 bottom-0 pt-[1.9rem] pb-[3.9rem]';
+			return 'h-[8rem] fixed max-w-[50rem] mx-auto inset-x-0 bottom-0 pt-[1.9rem] pb-[3.9rem]';
 		}
 		return 'rounded-[0.8rem] w-full';
 	};

--- a/src/app.features/calendar/components/MakeCalendar.tsx
+++ b/src/app.features/calendar/components/MakeCalendar.tsx
@@ -8,7 +8,6 @@ function MakeCalendar({ year, monthView, firstDay, lastDate, schedule, openModal
 	const { toDay, clickDay, modalCalData } = useStore();
 	const { month, day } = schedule;
 	const days = [];
-
 	const makeDay = (week: number) => {
 		const result = [];
 		// 첫 주

--- a/src/app.features/calendar/components/Modal/WorkList.tsx
+++ b/src/app.features/calendar/components/Modal/WorkList.tsx
@@ -35,8 +35,14 @@ function WorkList({ month, day, userName, currentUser }: Props) {
 				{userName.length > 0 ? (
 					userName
 						.sort((a, b) => {
-							const aTime = parseInt(a.workTime.split('~')[1].replace(':', ''), 10);
-							const bTime = parseInt(b.workTime.split('~')[1].replace(':', ''), 10);
+							let aTime = parseInt(a.workTime.split('~')[1].replace(':', ''), 10);
+							let bTime = parseInt(b.workTime.split('~')[1].replace(':', ''), 10);
+							if (aTime >= 2400) {
+								aTime -= 2400;
+							}
+							if (bTime >= 2400) {
+								bTime -= 2400;
+							}
 							return aTime - bTime;
 						})
 						.map((item, index) => (

--- a/src/app.features/calendar/components/Modal/WorkList.tsx
+++ b/src/app.features/calendar/components/Modal/WorkList.tsx
@@ -33,31 +33,37 @@ function WorkList({ month, day, userName, currentUser }: Props) {
 			</div>
 			<div>
 				{userName.length > 0 ? (
-					userName.map((item, index) => (
-						<div className="my-[2.4rem] flex items-center justify-between" key={index}>
-							<div className="flex items-center">
-								<ProfileImage size="lg" userProfileCode={item.userProfileCode} />
-								<span className="text-subhead2 text-g10 mx-[0.8rem]">{item.name}</span>
-								<span className="text-body2 text-g8">
-									{`${WorkListTimeView(item.workTime.split('~')[0])} - ${WorkListTimeView(
-										item.workTime.split('~')[1]
-									)}`}
-								</span>
+					userName
+						.sort((a, b) => {
+							const aTime = parseInt(a.workTime.split('~')[1].replace(':', ''), 10);
+							const bTime = parseInt(b.workTime.split('~')[1].replace(':', ''), 10);
+							return aTime - bTime;
+						})
+						.map((item, index) => (
+							<div className="my-[2.4rem] flex items-center justify-between" key={index}>
+								<div className="flex items-center">
+									<ProfileImage size="lg" userProfileCode={item.userProfileCode} />
+									<span className="text-subhead2 text-g10 mx-[0.8rem]">{item.name}</span>
+									<span className="text-body2 text-g8">
+										{`${WorkListTimeView(item.workTime.split('~')[0])} - ${WorkListTimeView(
+											item.workTime.split('~')[1]
+										)}`}
+									</span>
+								</div>
+								<div>
+									{item.name === currentUser && (
+										<button
+											className="bg-w px-[0.9rem] py-[0.4rem] border-solid border-[0.15rem] border-g4  rounded-[0.8rem]"
+											onClick={() => {
+												router.push(`${SERVICE_URL.calendarRecord}/${item.timeCardId}?title=${'modify'}`);
+											}}
+										>
+											<span className="text-[1.4rem] text-g9">출근수정</span>
+										</button>
+									)}
+								</div>
 							</div>
-							<div>
-								{item.name === currentUser && (
-									<button
-										className="bg-w px-[0.9rem] py-[0.4rem] border-solid border-[0.15rem] border-g4  rounded-[0.8rem]"
-										onClick={() => {
-											router.push(`${SERVICE_URL.calendarRecord}/${item.timeCardId}?title=${'modify'}`);
-										}}
-									>
-										<span className="text-[1.4rem] text-g9">출근수정</span>
-									</button>
-								)}
-							</div>
-						</div>
-					))
+						))
 				) : (
 					<div className="text-center mb-[1.2rem] mt-[2.4rem]">
 						<span className="text-body3 text-g7">아직 기록이 없어요.</span>

--- a/src/app.features/calendar/components/ModalWrap.tsx
+++ b/src/app.features/calendar/components/ModalWrap.tsx
@@ -29,7 +29,7 @@ function ModalWrap({ currentUser, closeModal }: Props) {
 		if (clickDayData <= toDayData && userName.length === 0) {
 			const data = getWorkList({ year: clickYear, month: clickMonth, day });
 			data.then((res) => {
-				console.log(res);
+				// console.log(res);
 				setUserName(res.data.data);
 			});
 		}

--- a/src/app.features/calendar/components/TotalSalary.tsx
+++ b/src/app.features/calendar/components/TotalSalary.tsx
@@ -2,14 +2,18 @@ import { useEffect, useState } from 'react';
 
 interface props {
 	data: number | undefined;
-	wage?: number;
+	wage: number;
 }
 function TotalSalary({ data, wage }: props) {
-	const [totalSalary, setTotalSalary] = useState<number>();
+	const [totalSalary, setTotalSalary] = useState<number | null>();
 
 	useEffect(() => {
-		if (data) {
-			setTotalSalary(data * 9620);
+		if (data && wage) {
+			if (data < 0) {
+				setTotalSalary(null);
+			} else {
+				setTotalSalary(data * wage);
+			}
 		}
 	}, [data]);
 

--- a/src/app.features/calendar/screens/CalendarScreen.tsx
+++ b/src/app.features/calendar/screens/CalendarScreen.tsx
@@ -25,7 +25,7 @@ function CalendarScreen({ currentUser }: Props) {
 		month: 0,
 		day: [],
 	});
-	const { year, month, setCalendar, modalCalData, isDayReset } = useStore();
+	const { year, month, setCalendar, modalCalData, isDayReset, setRecordComplete, recordComplete } = useStore();
 	const { isModalOpen, openModal, closeModal, closeAnimationModal } = useModal();
 	const { isJump, keypadChange } = useKeypadStore();
 	const router = useRouter();
@@ -89,10 +89,13 @@ function CalendarScreen({ currentUser }: Props) {
 	}, [month, getGrayRefetch, WorkData, isJump]);
 
 	useEffect(() => {
-		if (!isModalOpen) {
+		if (recordComplete) {
+			openModal();
+			setRecordComplete();
+		} else {
 			isDayReset();
 		}
-	}, [isModalOpen]);
+	}, []);
 
 	const salary = () => {
 		router.push(`${SERVICE_URL.calendarSalary}`);
@@ -167,7 +170,14 @@ function CalendarScreen({ currentUser }: Props) {
 				</div>
 			</div>
 			{isModalOpen && (
-				<Overlay overlayClickFn={() => closeAnimationModal()}>
+				<Overlay
+					overlayClickFn={() => {
+						closeAnimationModal();
+						setTimeout(() => {
+							isDayReset();
+						}, 500);
+					}}
+				>
 					<TopModal bgColor="bg-g1">
 						<ModalWrap currentUser={currentUser} closeModal={closeModal} />
 					</TopModal>

--- a/src/app.features/calendar/screens/WorkRecordScreen.tsx
+++ b/src/app.features/calendar/screens/WorkRecordScreen.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 import { useRouter } from 'next/router';
 import SetTimeButtons from 'src/app.components/Button/SetTimeButtons';
 import Modal from 'src/app.components/Modal/Modal';
@@ -6,14 +6,7 @@ import Overlay from 'src/app.components/Modal/Overlay';
 import Header from 'src/app.components/Header';
 import DelIcon from 'src/app.modules/assets/delete.svg';
 import Bar from 'src/app.components/app.base/Button/Bar';
-import {
-	parseSetWorkTime,
-	getDayOfWeek,
-	getFirstTime,
-	getLastTime,
-	viewTimeFormat,
-	workTimeDuplication,
-} from 'src/app.modules/util/calendar';
+import { parseSetWorkTime, getDayOfWeek, viewTimeFormat, workTimeDuplication } from 'src/app.modules/util/calendar';
 import KeypadDelIcon from 'src/app.modules/assets/inputDel.svg';
 import { getWorkTimeString } from 'src/app.modules/util/getWorkTimeString';
 import useModal from 'src/app.modules/hooks/useModal';
@@ -33,11 +26,11 @@ interface Props {
 function WorkRecordScreen({ WorkMutate, ModifyMutate, UserData, title, id }: Props) {
 	const { isModalOpen: isDelModalOpen, openModal: delOpenModal, closeModal: delCloseModal } = useModal();
 	const { isModalOpen: isDupleModalOpen, openModal: DupleOpenModal, closeModal: DupleCloseModal } = useModal();
-	const { clickDay, isDayReset } = useStore();
+	const { isModalOpen: isRecordModalOpen, openModal: RecordOpenModal, closeModal: RecordCloseModal } = useModal();
+	const { clickDay, setRecordComplete } = useStore();
 	const [year, month, day] = clickDay.split('.');
 	const [currentTime, setCurrentTime] = useState<IUser>();
-	const [workingFirstTime, setWorkingFirstTime] = useState('');
-	const [workingLastTime, setWorkingLastTime] = useState('');
+	const [workingTime, setWorkingTime] = useState([]);
 
 	const router = useRouter();
 	const {
@@ -53,9 +46,9 @@ function WorkRecordScreen({ WorkMutate, ModifyMutate, UserData, title, id }: Pro
 		const {
 			target: { name, value },
 		} = e;
-
 		setTime(value, name, openModalFlag as 'startTime' | 'endTime');
 	};
+
 	// 수정 버튼
 	const modifyBtn = async () => {
 		const workTimeData = getWorkTimeString(startTime, endTime);
@@ -64,7 +57,7 @@ function WorkRecordScreen({ WorkMutate, ModifyMutate, UserData, title, id }: Pro
 		const endSplit = Number(end.split(':')[0]) * 60 + Number(end.split(':')[1]);
 		const timeDiff = Number(Math.abs((startSplit - endSplit) / 60));
 		// 출근 시간 겹칠때
-		if (workTimeDuplication(workTimeData, workingFirstTime, workingLastTime)) {
+		if (workTimeDuplication(workTimeData, workingTime)) {
 			DupleOpenModal();
 			return;
 		}
@@ -75,14 +68,14 @@ function WorkRecordScreen({ WorkMutate, ModifyMutate, UserData, title, id }: Pro
 			// 수정하기
 			ModifyMutate({ year, month, day, workTime: workTimeData, workHour: timeDiff, timeCardId: Number(id) });
 		}
-		isDayReset();
+		setRecordComplete();
 	};
 
 	// 삭제 버튼
 	const delBtn = async () => {
 		const data = delWorkModify(Number(id));
 		data.then((res) => {
-			isDayReset();
+			setRecordComplete();
 			router.back();
 		});
 	};
@@ -97,10 +90,8 @@ function WorkRecordScreen({ WorkMutate, ModifyMutate, UserData, title, id }: Pro
 				getMyWorkTimes = getMyWorkTimes.filter((val: { timeCardId: number }) => val.timeCardId !== Number(id));
 			}
 			if (getMyWorkTimes.length > 0) {
-				const firstTime = getMyWorkTimes.map((val: { workTime: string }) => val.workTime.split('~')[0]);
-				const lastTime = getMyWorkTimes.map((val: { workTime: string }) => val.workTime.split('~')[1]);
-				setWorkingFirstTime(getFirstTime(firstTime));
-				setWorkingLastTime(getLastTime(lastTime));
+				const myWorkTimes = getMyWorkTimes.map((val: { workTime: string }) => val.workTime);
+				setWorkingTime(myWorkTimes);
 			}
 		});
 	};
@@ -164,6 +155,33 @@ function WorkRecordScreen({ WorkMutate, ModifyMutate, UserData, title, id }: Pro
 		}
 		return null;
 	};
+	const isFirstRender = useRef(true);
+
+	useEffect(() => {
+		if (openModalFlag !== null) {
+			if (isFirstRender.current) {
+				isFirstRender.current = false;
+				return;
+			}
+			if (openModalFlag === 'startTime') {
+				if (endTime.meridiem === null || endTime.hour === '' || endTime.minute === '') {
+					RecordOpenModal();
+				}
+			} else if (startTime.meridiem === null || startTime.hour === '' || startTime.minute === '') {
+				RecordOpenModal();
+			}
+		}
+	}, [openModalFlag]);
+
+	const toggleRecordOpenModalFlag = () => {
+		if (openModalFlag === 'startTime') {
+			setOpenModalFlag('endTime');
+		} else {
+			setOpenModalFlag('startTime');
+		}
+		RecordCloseModal();
+		isFirstRender.current = true;
+	};
 
 	return (
 		<>
@@ -193,9 +211,9 @@ function WorkRecordScreen({ WorkMutate, ModifyMutate, UserData, title, id }: Pro
 							onClick={() => setOpenModalFlag('startTime')}
 							className={`${
 								openModalFlag === 'startTime'
-									? 'text-primary text-subhead2 border-solid border-[0.15rem] border-primary'
-									: 'text-g7 text-body2'
-							} w-[50%] flex justify-between items-center pl-[1.2rem] h-[4.8rem] bg-g1 rounded-[0.8rem]`}
+									? 'text-primary text-subhead2 border-solid border-[0.15rem] border-primary pl-[1.05rem]'
+									: 'text-g7 text-body2 pl-[1.2rem]'
+							} w-[50%] flex justify-between items-center h-[4.8rem] bg-g1 rounded-[0.8rem]`}
 						>
 							{viewTimeFormat(startTime)}
 							{openModalFlag === 'startTime' && (
@@ -204,14 +222,14 @@ function WorkRecordScreen({ WorkMutate, ModifyMutate, UserData, title, id }: Pro
 								</div>
 							)}
 						</button>
-						<span className="text-subhead3 mx-[1rem]">~</span>
+						<span className="text-subhead3 mx-[1rem] text-g9">~</span>
 						<button
 							onClick={() => setOpenModalFlag('endTime')}
 							className={`${
 								openModalFlag === 'endTime'
-									? 'text-primary text-subhead2 border-solid border-[0.15rem] border-primary'
-									: 'text-g7 text-body2'
-							} w-[50%] flex justify-between items-center pl-[1.2rem] h-[4.8rem] bg-g1 rounded-[0.8rem]`}
+									? 'text-primary text-subhead2 border-solid border-[0.15rem] border-primary  pl-[1.05rem]'
+									: 'text-g7 text-body2 pl-[1.2rem]'
+							} w-[50%] flex justify-between items-center h-[4.8rem] bg-g1 rounded-[0.8rem]`}
 						>
 							{viewTimeFormat(endTime)}
 							{openModalFlag === 'endTime' && (
@@ -253,9 +271,18 @@ function WorkRecordScreen({ WorkMutate, ModifyMutate, UserData, title, id }: Pro
 			{isDupleModalOpen && (
 				<Overlay overlayClickFn={() => DupleCloseModal()}>
 					<Modal
-						title="내 출근시간이랑 겹칩니다."
+						title="금일 근무시간과 겹칩니다."
 						subTitle="다시 입력해 주세요!"
 						yesFn={() => DupleCloseModal()}
+						yesTitle="확인"
+					/>
+				</Overlay>
+			)}
+			{isRecordModalOpen && (
+				<Overlay overlayClickFn={() => toggleRecordOpenModalFlag()}>
+					<Modal
+						title={`${openModalFlag === 'startTime' ? '종료 시간' : '시작 시간'}을 다 입력해주세요`}
+						yesFn={() => toggleRecordOpenModalFlag()}
 						yesTitle="확인"
 					/>
 				</Overlay>

--- a/src/app.features/calendar/screens/WorkRecordScreen.tsx
+++ b/src/app.features/calendar/screens/WorkRecordScreen.tsx
@@ -53,9 +53,17 @@ function WorkRecordScreen({ WorkMutate, ModifyMutate, UserData, title, id }: Pro
 	const modifyBtn = async () => {
 		const workTimeData = getWorkTimeString(startTime, endTime);
 		const [start, end] = workTimeData.split('~');
-		const startSplit = Number(start.split(':')[0]) * 60 + Number(start.split(':')[1]);
-		const endSplit = Number(end.split(':')[0]) * 60 + Number(end.split(':')[1]);
-		const timeDiff = Number(Math.abs((startSplit - endSplit) / 60));
+		const [startHour, startMinute] = start.split(':').map(Number);
+		let endHour = end.split(':').map(Number)[0];
+		const endMinute = end.split(':').map(Number)[1];
+		// 24시 이후 시간 처리
+		if (endHour < startHour || (endHour === startHour && endMinute < startMinute)) {
+			endHour += 24;
+		}
+
+		const startSplit = startHour * 60 + startMinute;
+		const endSplit = endHour * 60 + endMinute;
+		const timeDiff = Math.abs((startSplit - endSplit) / 60);
 		// 출근 시간 겹칠때
 		if (workTimeDuplication(workTimeData, workingTime)) {
 			DupleOpenModal();

--- a/src/app.features/calendar/screens/WorkerScreen.tsx
+++ b/src/app.features/calendar/screens/WorkerScreen.tsx
@@ -10,6 +10,7 @@ import InfoIcon from 'src/app.modules/assets/calendar/salary/info.svg';
 import { SERVICE_URL } from 'src/app.modules/constants/ServiceUrl';
 import { useRouter } from 'next/router';
 import useModal from 'src/app.modules/hooks/useModal';
+import useUser from 'src/app.modules/hooks/user/useUser';
 import { getSalary } from '../api';
 import Keypad from '../components/Modal/Keypad';
 import SalaryDetail from '../components/SalaryDetail';
@@ -25,28 +26,24 @@ function WorkerScreen() {
 	const [salaryData, setSalaryData] = useState<ISalaryData[]>([]);
 	const [workHour, setWorkHour] = useState<number>();
 	const router = useRouter();
+	const { data: userData, isLoading: userLoading } = useUser();
 	const { data, isLoading, refetch } = useQuery(
 		['salary'],
 		() => getSalary({ year: String(year), month: String(month + 1) }),
 		{
 			onSuccess: (res) => {
 				setSalaryData(res.data.data);
+				const workHourFilter = res.data.data.reduce(
+					(acc: number, current: { workHour: number }) => acc + current.workHour,
+					-1
+				);
+				setWorkHour(workHourFilter);
 			},
 			onError: (error) => {
 				console.log(error);
 			},
-			retry: false,
-			refetchOnMount: false,
-			refetchOnReconnect: false,
-			refetchOnWindowFocus: false,
 		}
 	);
-
-	useEffect(() => {
-		const workHourFilter = salaryData.reduce((acc: number, current: { workHour: number }) => acc + current.workHour, 0);
-		setWorkHour(workHourFilter);
-	}, [salaryData]);
-
 	useEffect(() => {
 		refetch();
 	}, [year, month]);
@@ -85,7 +82,7 @@ function WorkerScreen() {
 							<span className="text-subhead3 text-w ml-[0.4rem]">이번달 급여</span>
 						</div>
 						<div className="pb-[1rem]">
-							<TotalSalary data={workHour} />
+							<TotalSalary data={workHour} wage={userData.wage} />
 						</div>
 						<div className="mx-[0.2rem] pb-[2rem]">
 							<div className="flex items-center">

--- a/src/app.features/calendar/store/index.ts
+++ b/src/app.features/calendar/store/index.ts
@@ -13,6 +13,8 @@ interface IStore {
 	modalCalData: (clickDay: string, workDay?: boolean) => void;
 	isDayReset: () => void;
 	setCalendar: (year: number, month: number) => void;
+	recordComplete: boolean;
+	setRecordComplete: () => void;
 }
 const today = new Date();
 const useStore = create<IStore>((set) => ({
@@ -27,6 +29,8 @@ const useStore = create<IStore>((set) => ({
 	modalCalData: (clickDay, workDay) => set(() => ({ clickDay, workDay })),
 	isDayReset: () => set(() => ({ clickDay: '' })),
 	setCalendar: (year, month) => set(() => ({ year, month })),
+	recordComplete: false,
+	setRecordComplete: () => set((state) => ({ ...state, recordComplete: !state.recordComplete })),
 }));
 
 export default useStore;

--- a/src/app.modules/util/calendar.ts
+++ b/src/app.modules/util/calendar.ts
@@ -168,7 +168,6 @@ export const viewTimeFormat = (time: Time) => {
 const fixTime = (time: string) => {
 	const [hour, minute] = time.split(':').map(Number);
 	if (hour === 24) {
-		// hour가 24인 경우, 00으로 변경
 		return new Date(`2023-01-01T00:${minute.toString().padStart(2, '0')}`);
 	}
 	return new Date(`2023-01-01T${time}`);
@@ -184,7 +183,14 @@ export const workTimeDuplication = (workTime: string, workingTime: string[]) => 
 		const minTime = fixTime(workingStart);
 		const maxTime = fixTime(workingEnd);
 
-		const innerTime = minTime < workEndTime && maxTime > workStartTime;
+		let innerTime = false;
+
+		if (minTime < maxTime) {
+			innerTime = minTime <= workEndTime && maxTime >= workStartTime;
+		} else {
+			innerTime =
+				minTime <= workEndTime || maxTime >= workStartTime || (workStartTime >= minTime && workEndTime <= maxTime);
+		}
 
 		if (innerTime) {
 			return true;

--- a/src/app.modules/util/calendar.ts
+++ b/src/app.modules/util/calendar.ts
@@ -57,17 +57,17 @@ export const formatTimeView = (time: string, type = 'reset') => {
 export const parseSetWorkTime = (workTime: string): IUser => {
 	const [meridiemLeft, hourLeft, minuteLeft] = formatTimeView(workTime, '')[0].split(' ');
 	const [meridiemRight, hourRight, minuteRight] = formatTimeView(workTime, '')[1].split(' ');
-	console.log();
+
 	return {
 		startTime: {
 			meridiem: meridiemLeft === '오전' ? 'am' : 'pm',
 			hour: hourLeft,
-			minute: minuteLeft === '00' ? '0' : minuteLeft,
+			minute: minuteLeft === '00' ? '0' : String(parseInt(minuteLeft, 10)),
 		},
 		endTime: {
 			meridiem: meridiemRight === '오전' ? 'am' : 'pm',
 			hour: hourRight,
-			minute: minuteRight === '00' ? '0' : minuteRight,
+			minute: minuteRight === '00' ? '0' : String(parseInt(minuteRight, 10)),
 		},
 	};
 };
@@ -138,52 +138,15 @@ export const WorkListTimeView = (time: string) => {
 	if (time === '12:00') {
 		return '오후 12:00';
 	}
+	if (hour === '24') {
+		return `오전 12:${minute}`;
+	}
 	if (hour >= '12') {
 		return `${hour}` === '12'
-			? `오전 ${hour}:${minute}`
-			: `오후 ${String(Number(hour) - 12).padStart(2, '0')}:${minute}`;
+			? `오후 ${parseInt(hour, 10)}:${minute}`
+			: `오후 ${String(parseInt(hour, 10) - 12)}:${minute}`;
 	}
-	return `오전 ${hour}:${minute}`;
-};
-
-export const getLastTime = (time: string[]) => {
-	return time.sort((a, b) => {
-		const [aHour, aMinute] = a.split(':').map(Number);
-		const [bHour, bMinute] = b.split(':').map(Number);
-		if (aHour < bHour) {
-			return 1;
-		}
-		if (aHour > bHour) {
-			return -1;
-		}
-		if (aMinute < bMinute) {
-			return 1;
-		}
-		if (aMinute > bMinute) {
-			return -1;
-		}
-		return 0;
-	})[0];
-};
-
-export const getFirstTime = (time: string[]) => {
-	return time.sort((a, b) => {
-		const [aHour, aMinute] = a.split(':').map(Number);
-		const [bHour, bMinute] = b.split(':').map(Number);
-		if (aHour < bHour) {
-			return -1;
-		}
-		if (aHour > bHour) {
-			return 1;
-		}
-		if (aMinute < bMinute) {
-			return -1;
-		}
-		if (aMinute > bMinute) {
-			return 1;
-		}
-		return 0;
-	})[0];
+	return `오전 ${parseInt(hour, 10)}:${minute}`;
 };
 
 export const viewTimeFormat = (time: Time) => {
@@ -197,21 +160,35 @@ export const viewTimeFormat = (time: Time) => {
 	if (time.meridiem === 'pm') {
 		merdiem = '오후';
 	}
-	const hour = time.hour.padStart(2, '0');
+	const { hour } = time;
 	const minute = time.minute ? `${time.minute.padStart(2, '0')}분` : '';
 	return `${merdiem} ${hour}시 ${minute}`;
 };
 
-export const workTimeDuplication = (workTime: string, startTime: string, endTime: string) => {
-	const [start, end] = workTime.split('~');
-	const minTime = new Date(`2023-01-01T${startTime}`);
-	const maxTime = new Date(`2023-01-01T${endTime}`);
-	const workStartTime = new Date(`2023-01-01T${start}`);
-	const workEndTime = new Date(`2023-01-01T${end}`);
-	if (start === startTime && end === endTime) {
-		return true;
+const fixTime = (time: string) => {
+	const [hour, minute] = time.split(':').map(Number);
+	if (hour === 24) {
+		// hour가 24인 경우, 00으로 변경
+		return new Date(`2023-01-01T00:${minute.toString().padStart(2, '0')}`);
 	}
-	const innerTime = minTime <= workStartTime && maxTime >= workEndTime;
-	const outTime = minTime >= workStartTime && maxTime <= workEndTime;
-	return innerTime || outTime;
+	return new Date(`2023-01-01T${time}`);
+};
+
+export const workTimeDuplication = (workTime: string, workingTime: string[]) => {
+	const [start, end] = workTime.split('~');
+	const workStartTime = fixTime(start);
+	const workEndTime = fixTime(end);
+
+	for (let i = 0; i < workingTime.length; i += 1) {
+		const [workingStart, workingEnd] = workingTime[i].split('~');
+		const minTime = fixTime(workingStart);
+		const maxTime = fixTime(workingEnd);
+
+		const innerTime = minTime < workEndTime && maxTime > workStartTime;
+
+		if (innerTime) {
+			return true;
+		}
+	}
+	return false;
 };


### PR DESCRIPTION
## PR 타입 (하나 이상의 PR 타입 선택)

- [v] 기능 추가
- [v] 기능 수정
- [] 기능 삭제
- [] 버그 수정
- [] 의존성, 환경 변수, 빌드 관련 코드 업데이트
- [] 문서 수정 (ex. README)

## 반영 브랜치

- feature/calendar -> main

## 변경 사항

- 시간 포맷 통합 1글자 일시 시간은 1글자 분은 2글자 (ex 9시 05분)
- 자신의 금일 근무시간과 겹칠 때 뜨는 모달 멘트 수정
- 오후 12시가 넘어갔을 때 오전으로 표기되는 이슈 해결
- 모달 띄울 때 스크롤 안되게 수정
- 출근 리스트 시간순으로 정렬
- 출근부 작성시 시간 선택 하는데 다 입력하지 않을 시 입력하라고 모달 띄우기
- 출근 완료, 출근 수정, 출근 삭제시 캘린더 페이지로 돌아오는데 확인을 위해 출근 리스트 모달 띄우기(사용자 편의)
- 시간 선택시 보더가 요소를 침범하는 이슈 해결
- '~'의 폰트 색상 g9으로 변경
- 급여 상세 페이지에서 날짜 변경시 급여가 0원으로 바뀌지 않는 이슈 해결
- 급여 계산에서 자정이 넘어갔을 때 제대로 계산이 안되던 이슈 해결
- 기존의 기본값인 9620원이 아닌 유저가 설정한 시급으로 총 급여 계산
- 그 외 출근부 작성 로직 강화

## 유의 사항

-
